### PR TITLE
Allowing nested values to load from raw

### DIFF
--- a/src/model/encoding/convertFromRawToDraftState.js
+++ b/src/model/encoding/convertFromRawToDraftState.js
@@ -56,10 +56,7 @@ function convertBlocksFromRaw(
       entityRanges = entityRanges || [];
       blocks = blocks || [];
 
-      key = parentKey && parentBlockRenderingConfig &&
-        parentBlockRenderingConfig.nestingEnabled ?
-          generateNestedKey(parentKey, key) :
-          key;
+      key = parentKey ? generateNestedKey(parentKey, key) : key
 
       var inlineStyles = decodeInlineStyleRanges(text, inlineStyleRanges);
 

--- a/src/model/transaction/ContentStateInlineStyle.js
+++ b/src/model/transaction/ContentStateInlineStyle.js
@@ -14,78 +14,82 @@
 'use strict';
 
 var CharacterMetadata = require('CharacterMetadata');
-var {Map} = require('immutable');
+var { Map } = require('immutable');
 
 import type ContentState from 'ContentState';
 import type SelectionState from 'SelectionState';
 
 var ContentStateInlineStyle = {
-  add: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    inlineStyle: string
-  ): ContentState {
-    return modifyInlineStyle(contentState, selectionState, inlineStyle, true);
-  },
+    add: function(
+        contentState: ContentState,
+        selectionState: SelectionState,
+        inlineStyle: string
+    ): ContentState {
+        return modifyInlineStyle(contentState, selectionState, inlineStyle, true);
+    },
 
-  remove: function(
-    contentState: ContentState,
-    selectionState: SelectionState,
-    inlineStyle: string
-  ): ContentState {
-    return modifyInlineStyle(contentState, selectionState, inlineStyle, false);
-  },
+    remove: function(
+        contentState: ContentState,
+        selectionState: SelectionState,
+        inlineStyle: string
+    ): ContentState {
+        return modifyInlineStyle(contentState, selectionState, inlineStyle, false);
+    },
 };
 
 function modifyInlineStyle(
-  contentState: ContentState,
-  selectionState: SelectionState,
-  inlineStyle: string,
-  addOrRemove: boolean
+    contentState: ContentState,
+    selectionState: SelectionState,
+    inlineStyle: string,
+    addOrRemove: boolean
 ): ContentState {
-  var blockMap = contentState.getBlockMap();
-  var startKey = selectionState.getStartKey();
-  var startOffset = selectionState.getStartOffset();
-  var endKey = selectionState.getEndKey();
-  var endOffset = selectionState.getEndOffset();
+    var blockMap = contentState.getBlockMap();
+    var startKey = selectionState.getStartKey();
+    var startOffset = selectionState.getStartOffset();
+    var endKey = selectionState.getEndKey();
+    var endOffset = selectionState.getEndOffset();
 
-  var newBlocks = blockMap
-    .skipUntil((_, k) => k === startKey)
-    .takeUntil((_, k) => k === endKey)
-    .concat(Map([[endKey, blockMap.get(endKey)]]))
-    .map((block, blockKey) => {
-      var sliceStart;
-      var sliceEnd;
+    var newBlocks = blockMap
+        .skipUntil((_, k) => k === startKey)
+        .takeUntil((_, k) => k === endKey)
+        .concat(Map([
+            [endKey, blockMap.get(endKey)]
+        ]))
+        .map((block, blockKey) => {
+            var sliceStart;
+            var sliceEnd;
 
-      if (startKey === endKey) {
-        sliceStart = startOffset;
-        sliceEnd = endOffset;
-      } else {
-        sliceStart = blockKey === startKey ? startOffset : 0;
-        sliceEnd = blockKey === endKey ? endOffset : block.getLength();
-      }
+            if (startKey === endKey) {
+                sliceStart = startOffset;
+                sliceEnd = endOffset;
+            } else {
+                sliceStart = blockKey === startKey ? startOffset : 0;
+                sliceEnd = blockKey === endKey ? endOffset : block.getLength();
+            }
 
-      var chars = block.getCharacterList();
-      var current;
-      while (sliceStart < sliceEnd) {
-        current = chars.get(sliceStart);
-        chars = chars.set(
-          sliceStart,
-          addOrRemove ?
-            CharacterMetadata.applyStyle(current, inlineStyle) :
-            CharacterMetadata.removeStyle(current, inlineStyle)
-        );
-        sliceStart++;
-      }
+            sliceEnd = Math.min(block.getLength(), sliceEnd);
 
-      return block.set('characterList', chars);
+            var chars = block.getCharacterList();
+            var current;
+            while (sliceStart < sliceEnd) {
+                current = chars.get(sliceStart);
+                chars = chars.set(
+                    sliceStart,
+                    addOrRemove ?
+                    CharacterMetadata.applyStyle(current, inlineStyle) :
+                    CharacterMetadata.removeStyle(current, inlineStyle)
+                );
+                sliceStart++;
+            }
+
+            return block.set('characterList', chars);
+        });
+
+    return contentState.merge({
+        blockMap: blockMap.merge(newBlocks),
+        selectionBefore: selectionState,
+        selectionAfter: selectionState,
     });
-
-  return contentState.merge({
-    blockMap: blockMap.merge(newBlocks),
-    selectionBefore: selectionState,
-    selectionAfter: selectionState,
-  });
 }
 
 module.exports = ContentStateInlineStyle;


### PR DESCRIPTION
Found that blocks were not nesting when converting back from raw. Serialization seemed to be working correctly but the nesting enabled flag was set to false on the ordered and unordered lists in the blockRendererMap by default even though it allows it to nest in the editor
